### PR TITLE
Use node 16 instead of 12

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -44,5 +44,5 @@ inputs:
     default: false
 
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'


### PR DESCRIPTION
Following up on deprecation from GitHub: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/